### PR TITLE
Fixes #497 by adding a SafetyHeight parameter

### DIFF
--- a/PortrayalCatalog/Rules/Bridge.lua
+++ b/PortrayalCatalog/Rules/Bridge.lua
@@ -5,10 +5,6 @@
 function Bridge(feature, featurePortrayal, contextParameters)
 	local viewingGroup = 12210
 
-	if feature.PrimitiveType ~= PrimitiveType.None then
-		featurePortrayal:AddInstructions('AlertReference:NavHazard')
-	end
-
 	if contextParameters.RadarOverlay then
 		featurePortrayal:AddInstructions('ViewingGroup:12210;DrawingPriority:24;DisplayPlane:OverRadar')
 	else
@@ -54,7 +50,7 @@ function Bridge(feature, featurePortrayal, contextParameters)
 	else
 		error('Invalid primitive type or mariner settings passed to portrayal')
 	end
-	
+
 	if feature.PrimitiveType ~= PrimitiveType.None and feature.featureName[1] and feature.featureName[1].name then
 		-- Note: S-52 only shows OBJNAM when CATBRG is not 2-8. It uses an offset of 3.51,0.
 		-- In S-101 the label is shown when available, and is offset further from the object.

--- a/PortrayalCatalog/Rules/SpanFixed.lua
+++ b/PortrayalCatalog/Rules/SpanFixed.lua
@@ -2,7 +2,9 @@ require 'S101AttributeSupport'
 
 -- from S-57 BRIDGE, CATBRG=1 (fixed bridge)
 function SpanFixed(feature, featurePortrayal, contextParameters)
-	featurePortrayal:AddInstructions('AlertReference:NavHazard')
+	if feature.verticalClearanceFixed.verticalClearanceValue <= contextParameters.SafetyHeight then
+		featurePortrayal:AddInstructions('AlertReference:NavHazard')
+	end
 
 	if feature.PrimitiveType == PrimitiveType.Curve then
 		if contextParameters.RadarOverlay then
@@ -25,7 +27,7 @@ function SpanFixed(feature, featurePortrayal, contextParameters)
 	else
 		error('Invalid primitive type or mariner settings passed to portrayal')
 	end
-	
+
 	-- Note: SpanFixed binds horizontalClearanceFixed and verticalClearanceFixed. It doesn't bind featureName.
 	if HasClearance(feature) then
 		local yOffset = 0

--- a/PortrayalCatalog/Rules/SpanOpening.lua
+++ b/PortrayalCatalog/Rules/SpanOpening.lua
@@ -2,8 +2,10 @@ require 'S101AttributeSupport'
 
 -- from S-57 BRIDGE, CATBRG=2 (opening bridge)
 function SpanOpening(feature, featurePortrayal, contextParameters)
-	featurePortrayal:AddInstructions('AlertReference:NavHazard')
-	
+	if feature.verticalClearanceClosed.verticalClearanceValue <= contextParameters.SafetyHeight then
+		featurePortrayal:AddInstructions('AlertReference:NavHazard')
+	end
+
 	if feature.PrimitiveType == PrimitiveType.Curve then
 		if contextParameters.RadarOverlay then
 			featurePortrayal:AddInstructions('ViewingGroup:12210;DrawingPriority:24;DisplayPlane:OverRadar')
@@ -26,7 +28,7 @@ function SpanOpening(feature, featurePortrayal, contextParameters)
 	else
 		error('Invalid primitive type or mariner settings passed to portrayal')
 	end
-	
+
 	-- Binds horizontalClearanceFixed, verticalClearanceClosed, verticalClearanceOpen
 	if HasClearance(feature) then
 		if feature.PrimitiveType == PrimitiveType.Curve then

--- a/PortrayalCatalog/portrayal_catalogue.xml
+++ b/PortrayalCatalog/portrayal_catalogue.xml
@@ -126,7 +126,7 @@
 		   <fileName>AISPHY05.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	
+	   </symbol>
 	   <symbol id="ANCBDNG2">
 		   <description>
 			   <name>ANCBDNG2</name>
@@ -136,7 +136,7 @@
 		   <fileName>ANCBDNG2.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>		   
+	   </symbol>
       <symbol id="BCNCAR01">
          <description>
             <name>BCNCAR01</name>
@@ -326,7 +326,7 @@
 		   <fileName>BCNGEN50.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="BCNISD21">
          <description>
             <name>BCNISD21</name>
@@ -566,7 +566,7 @@
 		   <fileName>BCNTOW50.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="BLKADJ01">
          <description>
             <name>BLKADJ01</name>
@@ -616,7 +616,7 @@
 		   <fileName>BOYBAR12.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>		   
+	   </symbol>
       <symbol id="BOYCAN01">
          <description>
             <name>BOYCAN01</name>
@@ -676,7 +676,7 @@
 		   <fileName>BOYCAN31.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>		   
+	   </symbol>
       <symbol id="BOYCAR01">
          <description>
             <name>BOYCAR01</name>
@@ -736,7 +736,7 @@
          <fileName>BOYCON10.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	  
+      </symbol>
       <symbol id="BOYCON11">
          <description>
             <name>BOYCON11</name>
@@ -746,7 +746,7 @@
          <fileName>BOYCON11.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	  
+      </symbol>
       <symbol id="BOYCON12">
          <description>
             <name>BOYCON12</name>
@@ -756,7 +756,7 @@
          <fileName>BOYCON12.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	  	   
+      </symbol>
       <symbol id="BOYCON30">
          <description>
             <name>BOYCON30</name>
@@ -766,7 +766,7 @@
          <fileName>BOYCON30.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	  	   
+      </symbol>
       <symbol id="BOYCON31">
          <description>
             <name>BOYCON31</name>
@@ -776,7 +776,7 @@
          <fileName>BOYCON31.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	  	   
+      </symbol>
       <symbol id="BOYDEF03">
          <description>
             <name>BOYDEF03</name>
@@ -916,7 +916,7 @@
 		   <fileName>BOYNDM02.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="BOYPIL01">
          <description>
             <name>BOYPIL01</name>
@@ -936,7 +936,7 @@
          <fileName>BOYPIL10.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-     </symbol>	   
+     </symbol>
 	   <symbol id="BOYPIL11">
 		   <description>
 			   <name>BOYPIL11</name>
@@ -1046,7 +1046,7 @@
 		   <fileName>BOYPIL60.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>			   
+	   </symbol>
       <symbol id="BOYSAW12">
          <description>
             <name>BOYSAW12</name>
@@ -1286,7 +1286,7 @@
 		   <fileName>BOYSPR60.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>		   
+	   </symbol>
       <symbol id="BOYSUP01">
          <description>
             <name>BOYSUP01</name>
@@ -2047,7 +2047,7 @@
          <fileName>DSCWTR51.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	   
+      </symbol>
       <symbol id="DSHAER01">
          <description>
             <name>DSHAER01</name>
@@ -2297,7 +2297,7 @@
          <fileName>EMDSCWTR.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	   
+      </symbol>
       <symbol id="EMDWRTC1">
          <description>
             <name>EMDWRTC1</name>
@@ -2617,7 +2617,7 @@
          <fileName>EMVTSARE.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	   
+      </symbol>
       <symbol id="ENTRES51">
          <description>
             <name>ENTRES51</name>
@@ -2697,7 +2697,7 @@
          <fileName>FERWHL03.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	   
+      </symbol>
      <symbol id="FERWHL04">
          <description>
             <name>FERWHL04</name>
@@ -2707,7 +2707,7 @@
          <fileName>FERWHL04.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	
+      </symbol>
 	   <symbol id="FLASTK01">
          <description>
             <name>FLASTK01</name>
@@ -2827,7 +2827,7 @@
 		   <fileName>FOULGD51.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
 	  <symbol id="FOULGND1">
 		   <description>
 			   <name>FOULGND1</name>
@@ -2837,7 +2837,7 @@
 		   <fileName>FOULGND1.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	  </symbol>	   
+	  </symbol>
       <symbol id="FRYARE51">
          <description>
             <name>FRYARE51</name>
@@ -3277,7 +3277,7 @@
          <fileName>MARCUL02P.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	   
+      </symbol>
       <symbol id="MARSHES1P">
          <description>
             <name>MARSHES1P</name>
@@ -3467,7 +3467,7 @@
 		   <fileName>PILBOP02.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="PILPNT02">
          <description>
             <name>PILPNT02</name>
@@ -3517,7 +3517,7 @@
 		   <fileName>POSGEN05.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="PRCARE12">
          <description>
             <name>PRCARE12</name>
@@ -4917,7 +4917,7 @@
 		   <fileName>SEAGRASS.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="SILBUI01">
          <description>
             <name>SILBUI01</name>
@@ -6267,7 +6267,7 @@
 		   <fileName>SOUNDSC3.svg</fileName>
 		   <fileType>Symbol</fileType>
 		   <fileFormat>SVG</fileFormat>
-	   </symbol>	   
+	   </symbol>
       <symbol id="SPRING02">
          <description>
             <name>SPRING02</name>
@@ -7067,7 +7067,7 @@
          <fileName>VOLCANO01.svg</fileName>
          <fileType>Symbol</fileType>
          <fileFormat>SVG</fileFormat>
-      </symbol>	   
+      </symbol>
       <symbol id="VEGATN04P">
          <description>
             <name>VEGATN04P</name>
@@ -7361,7 +7361,7 @@
          <fileName>COLREG01.xml</fileName>
          <fileType>LineStyle</fileType>
          <fileFormat>XML</fileFormat>
-      </lineStyle>	   
+      </lineStyle>
       <lineStyle id="CTNARE51">
          <description>
             <name>CTNARE51</name>
@@ -7841,7 +7841,7 @@
          <fileName>VTSARE51.xml</fileName>
          <fileType>LineStyle</fileType>
          <fileFormat>XML</fileFormat>
-      </lineStyle>   
+      </lineStyle>
    </lineStyles>
    <areaFills>
       <areaFill id="AIRARE02">
@@ -8097,10 +8097,10 @@
    </areaFills>
    <fonts/>
    <viewingGroups>
-   
+
 	  <!--********** BASE DISPLAY ELEMENTS **********-->
 	  <!-- 00000-09999 reserved for administrative purposes -->
-	  
+
 	  <!-- CHART INFORMATION - DISPLAY BASE -->
 	  <!-- 10000-10999 Reserved for chart information -->
 	  <!-- A, B - CHART FURNITURE -->
@@ -8240,11 +8240,11 @@
 	  <!-- Reserved -->
 	  <!-- 19000-19999 Reserved for chart information -->
 	  <!-- END CHART INFORMATION - DISPLAY BASE -->
-	  
+
 	  <!-- MARINERS INFORMATION - DISPLAY BASE -->
 	  <!-- See S-98 Annex C / IMO SN_Circ243 -->
 	  <!-- END MARINERS INFORMATION - DISPLAY BASE -->
-	  
+
 	  <!--********** END BASE DISPLAY ELEMENTS **********-->
 
 	  <!--********** STANDARD DISPLAY ELEMENTS **********-->
@@ -8362,7 +8362,7 @@
             <description>Standard: M - Traffic routes</description>
             <language>eng</language>
          </description>
-      </viewingGroup>	   
+      </viewingGroup>
       <viewingGroup id="25010">
          <description>
             <name>Leading line, clearing line (NAVLNE), traffic lane (TSSLPT), deep water route (DWRTPT), traffic separation area (TSEZNE), traffic separation line (TSELNE), traffic roundabout (TSSRON), traffic crossing (TSSCRS), precautionary area (PRCARE), traffic separation scheme boundary (TSSBND), deep water route centre line (DWRTCL), two way route part (TWRTPT), inshore traffic zone (ISTZNE)</name>
@@ -8597,7 +8597,7 @@
          </description>
       </viewingGroup>
 	  <!-- END CHART INFORMATION - STANDARD DISPLAY -->
-	  
+
 	  <!-- MARINERS' INFORMATION - STANDARD DISPLAY -->
 	  <!-- See S-98 Annex C / IMO SN_Circ243 -->
 	  <!-- END MARINERS' INFORMATION - STANDARD DISPLAY -->
@@ -8605,7 +8605,7 @@
 	  <!--********** END STANDARD DISPLAY ELEMENTS **********-->
 
 	  <!--********** OTHER DISPLAY ELEMENTS **********-->
-	  
+
 	  <!-- OTHER CHART INFORMATION -->
 	  <!-- A, B - INFORMATION ABOUT THE CHART DISPLAY -->
 	  <!-- 31000's: Information about the Chart Display -->
@@ -8851,7 +8851,7 @@
 
 	  <!-- P, Q, R, S - BUOYS & BEACONS, LIGHTS, FOG SIGNALS, RADAR -->
 	  <!-- 37000's: na -->
-	  
+
 	  <!-- T, U - SERVICES & SMALL CRAFT FACILITIES -->
 	  <!-- 38000's: Services -->
       <viewingGroup id="38010">
@@ -8882,18 +8882,18 @@
             <language>eng</language>
          </description>
       </viewingGroup>
-	  
+
 	  <!-- END OTHER CHART INFORMATION -->
-	  
+
 	  <!-- OTHER MARINERS' INFORMATION -->
 	  <!-- See S-98 Annex C / IMO SN_Circ243 -->
 	  <!-- END OTHER MARINERS' INFORMATION -->
-	
+
 	  <!--********** END OTHER DISPLAY ELEMENTS **********-->
 
       <!-- TEXT GROUPS -->
 	  <!-- Note: These act like Independent Mariner Selectors; they are independent of the selected display mode -->
-	  
+
 	  <!-- 00-10 reserved for future assignment by IHO -->
       <viewingGroup id="11">
         <description>
@@ -8979,12 +8979,12 @@
 	  <!-- 50-69 is defined in MARINERS TEXT -->
 	  <!-- 70-79 is defined in MANUFACTURERS TEXT -->
 	  <!-- 80-99 Future Requirements -->
-	  
+
       <!-- END TEXT GROUPS -->
 
      <!--********** Alert Catalog Viewing Groups **********-->
 	 <!-- Danger highlight and Indication highlights -->
-	 
+
       <viewingGroup id="53010">
         <description>
           <name>Safety Contour Highlight</name>
@@ -9026,7 +9026,7 @@
           <description>Alert highlight: Areas to be avoided</description>
           <language>eng</language>
         </description>
-      </viewingGroup>      
+      </viewingGroup>
       <viewingGroup id="53016">
         <description>
           <name>PSSA (Particularly Sensitive Sea Area) Highlight</name>
@@ -9054,7 +9054,7 @@
           <description>Alert highlight: User defined areas to be avoided</description>
           <language>eng</language>
         </description>
-      </viewingGroup>      
+      </viewingGroup>
       <viewingGroup id="53020">
         <description>
           <name>Military Practice Area Highlight</name>
@@ -9090,9 +9090,9 @@
           <language>eng</language>
         </description>
       </viewingGroup>
-      
-   <!--********** END Alert Catalog Viewing Groups **********--> 
-   
+
+   <!--********** END Alert Catalog Viewing Groups **********-->
+
    <!--********** Independent Mariner Selectors **********-->
    <!-- These operate independently of the selected display mode -->
       <viewingGroup id="90000">
@@ -9158,7 +9158,7 @@
           <language>eng</language>
         </description>
       </viewingGroup>
-   <!--********** END Viewing groups for Independent Mariner Selectors **********-->    
+   <!--********** END Viewing groups for Independent Mariner Selectors **********-->
    </viewingGroups>
    <foundationMode>
          <!-- A, B - CHART FURNITURE -->
@@ -9451,7 +9451,7 @@
          <viewingGroup>36020</viewingGroup>
          <viewingGroup>36040</viewingGroup>
          <viewingGroup>36050</viewingGroup>
-         <viewingGroup>36060</viewingGroup>		  
+         <viewingGroup>36060</viewingGroup>
          <viewingGroup>38010</viewingGroup>
          <viewingGroup>38030</viewingGroup>
          <viewingGroup>38200</viewingGroup>
@@ -9528,7 +9528,7 @@
        <viewingGroup>90040</viewingGroup>
      </viewingGroupLayer>
 	 <!-- END Independent mariner selectors -->
-	 
+
      <!-- TEXT LAYER GROUPS (not part of a display mode / IMO display category) -->
      <viewingGroupLayer id="100">
        <description>
@@ -9793,7 +9793,7 @@
 
 	 <!-- Reintroduced support PC #144 Display parameters for 'New Text' [PSWG #104] , nameUsage with featureName -->
 	  <!--Temporarily removed via #61. Awaiting resolution of https://github.com/iho-ohi/S-101-Documentation-and-FC/issues/60 and https://github.com/S-101-Portrayal-subWG/Working-Documents/issues/104 -->
-	 
+
      <parameter id="NationalLanguage">
        <description>
          <name>National language</name>
@@ -9809,7 +9809,15 @@
 		</errorMessage>
 	   </validate>
      </parameter>
-	 
+	  <parameter id="SafetyHeight">
+         <description>
+            <name>Safety height</name>
+            <description>Selected safety height</description>
+            <language>eng</language>
+         </description>
+         <type>Double</type>
+         <default>20</default>
+     </parameter>
    </context>
    <rules>
       <ruleFile id="main">
@@ -11197,7 +11205,7 @@
 		   <fileType>Rule</fileType>
 		   <fileFormat>LUA</fileFormat>
 		   <ruleType>SubTemplate</ruleType>
-	  </ruleFile>	   
+	  </ruleFile>
       <ruleFile id="MilitaryPracticeArea">
          <description>
             <name>MilitaryPracticeArea</name>


### PR DESCRIPTION
Modified the SpanFixed and SpanOpening rules to only emit an AlertReference if the vertical clearance is less than the safety height. Also removed the alert from the bridge rule, per AHO's comments as it is redundant.